### PR TITLE
Adding interpreter aliasing with linking: python -> python[version].

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ envs {
   minicondaVersion = 'latest'
   packages = ["pip", "setuptools"]
 
-  conda "django19", "2.7", ["django==1.9"]
+  conda "django19", "2.7", ["django==1.9"], true
 
-  conda "python34_64", "3.4", ["ipython==2.1", "django==1.6", "behave", "jinja2", "tox==2.0"]
+  conda "python34_64", "3.4", ["ipython==2.1", "django==1.6", "behave", "jinja2", "tox==2.0"], true
 
   jython "jython25", []
 }

--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsExtension.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsExtension.groovy
@@ -16,9 +16,16 @@ class PythonEnvsExtension {
     List<PythonEnv> condaEnvs = []
     List<CreateFile> files = []
     Boolean _64Bits = false
-    
-    void conda(final String envName, final String version, final List<String> packages) {
-        condaEnvs << new VersionedPythonEnv(envName, version, packages)
+
+    /**
+     * @param envName name of environment like "env_for_django"
+     * @param version py version like "3.4"
+     * @param packages collection of py packages to install
+     * @param linkWithVersion if true, binary will be linked with version name.
+     * I.e. "python" will be have "python2.7" link (same for exe file). Used for envs line tox.
+     */
+    void conda(final String envName, final String version, final List<String> packages, final boolean linkWithVersion) {
+        condaEnvs << new VersionedPythonEnv(envName, version, packages, linkWithVersion)
     }
     
     void jython(final String envName, final List<String> packages) {
@@ -42,10 +49,12 @@ class PythonEnv {
 
 class VersionedPythonEnv extends PythonEnv {
     String version
+    boolean linkWithVersion
 
-    VersionedPythonEnv(String name, String version, List<String> packages) {
+    VersionedPythonEnv(String name, String version, List<String> packages, boolean linkWithVersion) {
         super(name, packages)
         this.version = version
+        this.linkWithVersion = linkWithVersion
     }
 }
 

--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
@@ -3,8 +3,10 @@ package com.jetbrains.python.envs
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.Exec
 import org.gradle.util.VersionNumber
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 class PythonEnvsPlugin implements Plugin<Project> {
     def os = System.getProperty('os.name').replaceAll(' ', '')
@@ -200,7 +202,20 @@ class PythonEnvsPlugin implements Plugin<Project> {
                                 args envs.packages
                             }
 
-                            pipInstall(project, "$envs.envsDirectory/$name", e.packages)
+                            def envPath = "$envs.envsDirectory/$name"
+                            pipInstall(project, envPath, e.packages)
+
+                            if (e.linkWithVersion) {
+
+                                def win = Os.isFamily(Os.FAMILY_WINDOWS);
+
+                                def ext = "${win ? '.exe' : ''}"
+                                final Path source = Paths.get(envPath, "python" + ext);
+                                final Path dest = Paths.get(envPath, "python" + e.version.toString() + ext );
+
+                                Files.createLink(dest, source);
+                            }
+
                         }
                     }
                 }


### PR DESCRIPTION
For some cases like tox there should be binary with python version included in path. So, instead if python we need python2.7. Instead of python.exe we need python2.7.exe.

 This change adds bool argument to "conda" that enables this aliasing using fs-specific linking (Java7 API)