### PR TITLE
Install packages via `conda install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ envs {
 
   conda "python34_64", "3.4", ["ipython==2.1", "django==1.6", "behave", "jinja2", "tox==2.0"], true
 
+  conda_install "pyqt_env", "2.7", ["pyqt"], false
+
   jython "jython25", []
 }
 ```
@@ -40,8 +42,13 @@ Then invoke the `build_envs` task.
 This will download and install the latest versions of Miniconda both for 32 and 64 bits and Jython to 
 `buildDir/pythons`.
 
-Then it will create `django19` and `python34_64` conda envs and `jython25` Jython env in `buildDir/envs`,
+Then it will create `django19`, `python34_64` and `pyqt_env` conda envs and `jython25` Jython env in `buildDir/envs`,
 installing all the libraries listed correspondingly.
+For `conda` libraries will be installed via `pip install` command.
+For `conda_install` command libraries will be installed via `conda install` command. It enables to install, for example,
+PyQt in env.
+If the last boolean parameter is true, binary will be linked with version name, i.e. "python" will have "python2.7"
+link (same for exe file). Used for envs like tox.
 
 
 License

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ This will download and install the latest versions of Miniconda both for 32 and 
 
 Then it will create `django19`, `python34_64` and `pyqt_env` conda envs and `jython25` Jython env in `buildDir/envs`,
 installing all the libraries listed correspondingly.
-For `conda` libraries will be installed via `pip install` command.
+
+For `conda` libraries will be installed via `pip install` command.  
 For `conda_install` command libraries will be installed via `conda install` command. It enables to install, for example,
 PyQt in env.
+
 If the last boolean parameter is true, binary will be linked with version name, i.e. "python" will have "python2.7"
 link (same for exe file). Used for envs like tox.
 

--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsExtension.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsExtension.groovy
@@ -25,7 +25,12 @@ class PythonEnvsExtension {
      * I.e. "python" will be have "python2.7" link (same for exe file). Used for envs line tox.
      */
     void conda(final String envName, final String version, final List<String> packages, final boolean linkWithVersion) {
-        condaEnvs << new VersionedPythonEnv(envName, version, packages, linkWithVersion)
+        condaEnvs << new VersionedPythonEnv(envName, version, packages, linkWithVersion, false)
+    }
+
+    void conda_install(final String envName, final String version, final List<String> packages,
+                       final boolean linkWithVersion) {
+        condaEnvs << new VersionedPythonEnv(envName, version, packages, linkWithVersion, true)
     }
     
     void jython(final String envName, final List<String> packages) {
@@ -50,11 +55,14 @@ class PythonEnv {
 class VersionedPythonEnv extends PythonEnv {
     String version
     boolean linkWithVersion
+    boolean useCondaInstall
 
-    VersionedPythonEnv(String name, String version, List<String> packages, boolean linkWithVersion) {
+    VersionedPythonEnv(String name, String version, List<String> packages, boolean linkWithVersion,
+                       boolean useCondaInstall) {
         super(name, packages)
         this.version = version
         this.linkWithVersion = linkWithVersion
+        this.useCondaInstall = useCondaInstall
     }
 }
 


### PR DESCRIPTION
Add new command `conda_install` which creates conda envs, but installs packages without pip, using `conda install` command. It helps to install, for example, PyQt in virtual env.