### PR TITLE
Use Miniconda2 for latest version

### DIFF
--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
@@ -25,7 +25,8 @@ class PythonEnvsPlugin implements Plugin<Project> {
         }
         def myName = "Miniconda2"
         // versions <= 3.16 were named "Miniconda-${version}"
-        if (VersionNumber.parse(myExt.minicondaVersion) <= VersionNumber.parse("3.16")) {
+        // But latest in special case: it should always use Miniconda2, even VersionNumber.parse parses latest as 0.0.0
+        if (myExt.minicondaVersion != "latest" && VersionNumber.parse(myExt.minicondaVersion) <= VersionNumber.parse("3.16")) {
             myName = "Miniconda"
         }
         project.dependencies {


### PR DESCRIPTION
* There is a logic that uses Miniconda for <3.16 and Miniconda2 for 3.16+. But "latest" is processed as 0.0.0 (<3.16) which leads to errors.