### PR TITLE
Add environment name to condaenv

### DIFF
--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
@@ -455,7 +455,7 @@ class PythonEnvsPlugin implements Plugin<Project> {
                             project.logger.quiet("Creating condaenv '$env.name' at $env.envDir directory")
                             project.exec {
                                 executable getExecutable("conda", env.sourceEnv)
-                                args "create", "-p", env.envDir, "-y", "python=$env.version"
+                                args "create", "-n", env.name, "-p", env.envDir, "-y", "python=$env.version"
                                 args env.condaPackages
                             }
 


### PR DESCRIPTION
It's difficult to use a condaenv that doesn't have a name defined.

https://conda.io/docs/user-guide/tasks/manage-environments.html