### PR TITLE
Remove repository requirement

### DIFF
--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
@@ -239,10 +239,6 @@ class PythonEnvsPlugin implements Plugin<Project> {
     void apply(Project project) {
         PythonEnvsExtension envs = project.extensions.create("envs", PythonEnvsExtension.class)
 
-        project.repositories {
-            mavenCentral()
-        }
-
         project.configurations {
             jython
         }


### PR DESCRIPTION
Attempting to use this plugin in companies that ban the use of external repositories fails.  This pushes the requirement of having a suitable repo out to the users of the plugin.