### PR TITLE
Follow uri migration

### DIFF
--- a/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
+++ b/src/main/groovy/com/jetbrains/python/envs/PythonEnvsPlugin.groovy
@@ -23,7 +23,7 @@ class PythonEnvsPlugin implements Plugin<Project> {
         final String arch = "$osName-x86${conda.is64 ? '_64' : ''}"
         final String ext = isWindows ? "exe" : "sh"
 
-        return new URL("https://repo.continuum.io/$repository/${conda.version}-$arch.$ext")
+        return new URL("https://repo.anaconda.com/$repository/${conda.version}-$arch.$ext")
     }
 
     private static File getExecutable(String executable, Python env = null, File dir = null, EnvType type = null) {


### PR DESCRIPTION
Conda is migrating from continuum.io to anaconda.com

> we recommend all users switch to using https://repo.anaconda.com/ as soon as possible and not depend on having https://repo.continuum.io/ available indefinitely.

https://www.anaconda.com/blog/anaconda-repository-changes-afoot
https://github.com/conda/conda/issues/6886